### PR TITLE
Fix default value when using sequelize fn

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -107,10 +107,10 @@ function reverseSequelizeColType(col, prefix = 'Sequelize.') {
 }
 
 function reverseSequelizeDefValueType(defaultValue, prefix = 'Sequelize.') {
-  if (defaultValue.fn === "Now") {
+  if (typeof defaultValue.fn !== "undefined") {
     return {
       internal: true,
-      value: `${prefix}fn('NOW')`,
+      value: `${prefix}fn('${defaultValue.fn}')`,
     };
   }
 

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -107,6 +107,13 @@ function reverseSequelizeColType(col, prefix = 'Sequelize.') {
 }
 
 function reverseSequelizeDefValueType(defaultValue, prefix = 'Sequelize.') {
+  if (defaultValue.fn === "Now") {
+    return {
+      internal: true,
+      value: `${prefix}fn('NOW')`,
+    };
+  }
+
   if (defaultValue instanceof Sequelize.NOW) {
     return {
       internal: true,


### PR DESCRIPTION
for example postgres function "now()" should be converted into
```
                "updated_at": {
                    "type": Sequelize.DATE,
                    "defaultValue": Sequelize.fn('Now'),
                    "allowNull": false
                }

```
which is not the case now