### PR TITLE
fix diff bug on validate column attribute

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -195,6 +195,8 @@ function reverseModels(sequelize, models) {
           attributes[column][property] = _val;
         }
 
+        if (property === 'validate') { delete attributes[column][property]; }
+
         // remove getters, setters...
         if (typeof attributes[column][property] === 'function') { delete attributes[column][property]; }
       }


### PR DESCRIPTION
if there is a validation defined for a column, it seems like deepDiff detects that there is a column change presumably because the validate field is an object