### PR TITLE
various fixes to make it work with sequelize: ^5.10.3,

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![NPM](https://nodei.co/npm/sequelize-auto-migrations-ng.png?compact=true)](https://nodei.co/npm/sequelize-auto-migrations-ng/)
 
 # sequelize-auto-migrations-ng
-Migration generator for sequelize.
+Migration generator for sequelize with true migrations in database.
 
 This package provides one tool:
 * `makemigration` - tool for create new migrations
@@ -23,6 +23,22 @@ This package provides one tool:
 `node ./node_modules/sequelize-auto-migrations/bin/makemigration --preview`
 
 `makemigration` tool creates a table, `SequelizeMetaMigrations` in your database, that is used to calculate difference to the next migration. Do not remove it!
+
+You could add these 2 scripts to `package.json`:
+
+```
+"scripts": {
+    ...
+    "migrate": "DEBUG=* node ./node_modules/.bin/sequelize db:migrate  --debug",
+    "makemigrations": "DEBUG=* node ./node_modules/sequelize-auto-migrations-ng/bin/makemigration -d -v ",
+```
+
+And then use
+
+```
+npm run makemigration -- --name initial_version
+npm run migrate
+```
 
 
 ## Executing migrations

--- a/bin/makemigration.js
+++ b/bin/makemigration.js
@@ -100,7 +100,7 @@ queryInterface.createTable('SequelizeMeta', {
   // We get the state at the last migration executed
     sequelize.query('SELECT name FROM `SequelizeMeta` ORDER BY "name" desc limit 1', { type: sequelize.QueryTypes.SELECT })
       .then(([lastExecutedMigration]) => {
-        sequelize.query(`SELECT state FROM \`SequelizeMetaMigrations\` where "revision" = '${lastExecutedMigration === undefined ? -1 : lastExecutedMigration.name.split('-')[0]}'`, { type: sequelize.QueryTypes.SELECT })
+        sequelize.query(`SELECT state FROM \`SequelizeMetaMigrations\` where \`revision\` = '${lastExecutedMigration === undefined ? -1 : lastExecutedMigration.name.split('-')[0]}'`, { type: sequelize.QueryTypes.SELECT })
           .then(([lastMigration]) => {
             if (lastMigration !== undefined) previousState = lastMigration.state;
 

--- a/bin/makemigration.js
+++ b/bin/makemigration.js
@@ -98,7 +98,7 @@ queryInterface.createTable('SequelizeMeta', {
     },
   }).then(() => {
   // We get the state at the last migration executed
-    sequelize.query('SELECT name FROM `SequelizeMeta` ORDER BY "name" desc limit 1', { type: sequelize.QueryTypes.SELECT })
+    sequelize.query('SELECT name FROM `SequelizeMeta` ORDER BY `name` desc limit 1', { type: sequelize.QueryTypes.SELECT })
       .then(([lastExecutedMigration]) => {
         sequelize.query(`SELECT state FROM \`SequelizeMetaMigrations\` where \`revision\` = '${lastExecutedMigration === undefined ? -1 : lastExecutedMigration.name.split('-')[0]}'`, { type: sequelize.QueryTypes.SELECT })
           .then(([lastMigration]) => {

--- a/bin/makemigration.js
+++ b/bin/makemigration.js
@@ -98,9 +98,9 @@ queryInterface.createTable('SequelizeMeta', {
     },
   }).then(() => {
   // We get the state at the last migration executed
-    sequelize.query('SELECT name FROM "SequelizeMeta" ORDER BY "name" desc limit 1', { type: sequelize.QueryTypes.SELECT })
+    sequelize.query('SELECT name FROM `SequelizeMeta` ORDER BY "name" desc limit 1', { type: sequelize.QueryTypes.SELECT })
       .then(([lastExecutedMigration]) => {
-        sequelize.query(`SELECT state FROM "SequelizeMetaMigrations" where "revision" = '${lastExecutedMigration === undefined ? -1 : lastExecutedMigration.name.split('-')[0]}'`, { type: sequelize.QueryTypes.SELECT })
+        sequelize.query(`SELECT state FROM \`SequelizeMetaMigrations\` where "revision" = '${lastExecutedMigration === undefined ? -1 : lastExecutedMigration.name.split('-')[0]}'`, { type: sequelize.QueryTypes.SELECT })
           .then(([lastMigration]) => {
             if (lastMigration !== undefined) previousState = lastMigration.state;
 

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -172,8 +172,7 @@ function reverseModels(sequelize, models) {
   delete models.default;
 
   for (const model in models) {
-    const attributes = models[model].attributes;
-
+    const attributes = models[model].attributes || models[model].rawAttributes;
     for (const column in attributes) {
       delete attributes[column].Model;
       delete attributes[column].fieldName;
@@ -233,7 +232,7 @@ function reverseModels(sequelize, models) {
       schema: attributes,
     };
 
-    if (models[model].options.indexes.length > 0) {
+    if (models[model].options.indexes && models[model].options.indexes.length > 0) {
       const idx_out = {};
       for (const _i in models[model].options.indexes) {
         const index = parseIndex(models[model].options.indexes[_i]);
@@ -476,7 +475,7 @@ function getMigration(actions) {
     const vals = [];
     for (const k in obj) {
       if (k === 'seqType') {
-        vals.push(`"type": ${obj[k]}`);
+        vals.push(`"type": "${obj[k]}"`);
         continue;
       }
 

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -390,6 +390,14 @@ function parseDifference(previousState, currentState) {
             actions.push({
               actionType: 'changeColumn', tableName, attributeName: df.path[2], options, depends,
             });
+          } else if (df.path[1] === 'indexes') {
+            for (const _i in df.rhs) {
+              actions.push(_.extend({
+                actionType: 'addIndex',
+                tableName,
+                depends: [tableName],
+              }, _.clone(df.rhs[_i])));
+            }
           }
         }
         break;


### PR DESCRIPTION
- Use compatible quotes in query, doublequotes are not supported with default SQLmode (at least in mysql5)
- wrap types in strings, fixes error `VARCHAR is not defined`, in `VARCHAR(50)`
- `attributes` are now `rowAttributes`, left compatibility with previous versions
- handle case when indexes are not defined (also compatible with previous code)